### PR TITLE
fix: properly disable MutationObserver when toggling off

### DIFF
--- a/src/scripts/DOMObserver.js
+++ b/src/scripts/DOMObserver.js
@@ -23,6 +23,7 @@ function buildDOMObserverScript(customTexts) {
     // Prevents double-injection if the script is evaluated again on the same context.
     if (window.__AA_OBSERVER_ACTIVE) return 'already-active';
     window.__AA_OBSERVER_ACTIVE = true;
+    window.__AA_PAUSED = false;
 
     // ═══ WEBVIEW GUARD (deferred) ═══
     // Moved inside scanAndClick() to avoid race condition:
@@ -149,6 +150,7 @@ function buildDOMObserverScript(customTexts) {
 
     function scanAndClick() {
         pruneCooldowns();
+        if (window.__AA_PAUSED) return null;
 
         // ═══ DEFERRED WEBVIEW GUARD ═══
         // Dynamically checks DOM structure on each scan instead of at injection time.
@@ -190,7 +192,7 @@ function buildDOMObserverScript(customTexts) {
     // (React mounts button → then streams LLM text). A trailing debounce
     // would delay clicks until streaming stops, which is the wrong behavior.
     var debounceTimer = null;
-    var observer = new MutationObserver(function() {
+    window.__AA_OBSERVER = new MutationObserver(function() {
         if (debounceTimer) return;
         debounceTimer = setTimeout(function() {
             debounceTimer = null;
@@ -198,7 +200,7 @@ function buildDOMObserverScript(customTexts) {
         }, 100);
     });
 
-    observer.observe(document.body, {
+    window.__AA_OBSERVER.observe(document.body, {
         childList: true,
         subtree: true
     });


### PR DESCRIPTION
## Problem

Toggling AutoAccept OFF only closes the CDP WebSocket connection but leaves injected MutationObservers running autonomously in webview contexts. This causes buttons to keep being auto-clicked even after the user disables the extension.

## Root Cause

The MutationObserver was stored as an anonymous local variable inside the IIFE, making it impossible to disconnect from outside. `ConnectionManager.stop()` had no way to reach into the browser context to stop the observer.

## Fix

- **DOMObserver.js**: Store observer on `window.__AA_OBSERVER`; add `window.__AA_PAUSED` safety check in `scanAndClick()`; clear paused flag on re-injection
- **ConnectionManager.js**: New [_disableObservers()](cci:1://file:///d:/ONE/CODE/AntiGravity-AutoAccept/src/cdp/ConnectionManager.js:311:4-337:5) sends kill signal (disconnect + clear flags) to all active sessions before closing WebSocket. Uses synchronous `ws.send()` fire-and-forget — graceful WebSocket close guarantees delivery.

## Tests

3 new tests added (52 total, all passing):
- Paused window prevents button clicks
- Re-injection after disable clears flags correctly
- Observer accessible on `window.__AA_OBSERVER`