### PR TITLE
fix: prevent filename buttons from false-positive matching in findButton()

### DIFF
--- a/src/scripts/DOMObserver.js
+++ b/src/scripts/DOMObserver.js
@@ -97,9 +97,7 @@ function buildDOMObserverScript(customTexts) {
             }
             var nodeText = (node.textContent || '').trim().toLowerCase();
             if (nodeText.length > 50) continue;
-            var isMatch = nodeText === text || 
-                (text.length >= 5 && nodeText.startsWith(text) && nodeText.length <= text.length * 3) ||
-                (nodeText.startsWith(text + ' ') && nodeText.length <= text.length * 5);
+            var isMatch = nodeText === text || nodeText.startsWith(text + ' ');
             if (isMatch) {
                 var clickable = closestClickable(node);
                 var tag2 = (clickable.tagName || '').toLowerCase();

--- a/test/permission-engine.test.js
+++ b/test/permission-engine.test.js
@@ -295,6 +295,39 @@ test('data-testid on plain DIV is NOT clicked', () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════
+console.log('\n\x1b[1m--- Filename False Positive Prevention ---\x1b[0m');
+
+test('"accept-test.js" must NOT match "accept" (filename in cascade bar)', () => {
+    const btn = new El('BUTTON', 'accept-test.js');
+    run(makeDoc([btn]));
+    assert.ok(!btn._clicked, 'Filename button should NOT be clicked');
+});
+
+test('"accept_utils.py" must NOT match "accept"', () => {
+    const btn = new El('BUTTON', 'accept_utils.py');
+    run(makeDoc([btn]));
+    assert.ok(!btn._clicked);
+});
+
+test('"expand.js" must NOT match "expand"', () => {
+    const btn = new El('BUTTON', 'expand.js');
+    run(makeDoc([btn]));
+    assert.ok(!btn._clicked);
+});
+
+test('"Accept All" still matches "accept" (space after keyword)', () => {
+    const btn = new El('BUTTON', 'Accept All');
+    run(makeDoc([btn]));
+    assert.ok(btn._clicked);
+});
+
+test('"Run Alt+d" still matches "run" (space after keyword)', () => {
+    const btn = new El('BUTTON', 'Run Alt+d');
+    run(makeDoc([btn]));
+    assert.ok(btn._clicked);
+});
+
+// ═════════════════════════════════════════════════════════════════════
 console.log('\n\x1b[1m--- Expand Banner (Pass 2) ---\x1b[0m');
 
 test('"Expand" clicked when no action buttons exist', () => {


### PR DESCRIPTION
### Background

The `startsWith(text)` rule in `findButton()` would match cascade bar filename buttons like `accept-test.js` against the `accept` keyword, causing the observer to repeatedly click file-list buttons instead of the actual Accept action button.

### Changes

| File | Change | +/- |
|------|--------|-----|
| [src/scripts/DOMObserver.js](cci:7://file:///d:/ONE/CODE/AntiGravity-AutoAccept/src/scripts/DOMObserver.js:0:0-0:0) | Simplify matching: exact match OR keyword+space prefix | +1 ~-3~ |
| [test/permission-engine.test.js](cci:7://file:///d:/ONE/CODE/AntiGravity-AutoAccept/test/permission-engine.test.js:0:0-0:0) | Add 5 regression tests for filename false-positive prevention | +33 |

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `accept-test.js` | ✅ Matched as `accept` | ❌ Skipped |
| `expand.js` | ✅ Matched as `expand` | ❌ Skipped |
| `Accept All` | ✅ Matched | ✅ Matched |
| `Run Alt+d` | ✅ Matched | ✅ Matched |

### Verification

- `node test/permission-engine.test.js` → 54 passed, 0 failed
