### PR TITLE
fix: isolate CDP targets per window using workspace name matching

### DIFF
--- a/src/cdp/ConnectionManager.js
+++ b/src/cdp/ConnectionManager.js
@@ -13,11 +13,13 @@ class ConnectionManager {
      * @param {Function} options.log - Logging function
      * @param {Function} options.getPort - Returns configured CDP port
      * @param {Function} options.getCustomTexts - Returns custom button texts array
+     * @param {string} [options.windowName] - Current workspace name for window isolation
      */
-    constructor({ log, getPort, getCustomTexts }) {
+    constructor({ log, getPort, getCustomTexts, windowName }) {
         this.log = log;
         this.getPort = getPort;
         this.getCustomTexts = getCustomTexts;
+        this.windowName = windowName || '';  // For window isolation — filters page targets by title
 
         // Connection state
         this.ws = null;
@@ -211,12 +213,25 @@ class ConnectionManager {
     }
 
     async _handleNewTarget(targetInfo) {
-        const { targetId, type, url } = targetInfo;
+        const { targetId, type, url, title } = targetInfo;
         if (!this._isCandidate(targetInfo)) return;
         if (this.sessions.has(targetId)) return;
         if (this.ignoredTargets.has(targetId)) return;
 
         const shortId = targetId.substring(0, 6);
+
+        // ═══ WINDOW ISOLATION ═══
+        // CDP port is process-wide — all windows' targets are visible.
+        // Filter page targets by matching title to current workspace name,
+        // so we only inject into our own window's workbench frame.
+        if (type === 'page' && this.windowName) {
+            const pageTitle = (title || '').toLowerCase();
+            if (!pageTitle.includes(this.windowName.toLowerCase())) {
+                this.ignoredTargets.add(targetId);
+                this.log(`[CDP] ✗ Skipped [${shortId}] — window "${(title || '').substring(0, 40)}" ≠ "${this.windowName}"`);
+                return;
+            }
+        }
 
         try {
             const attachMsg = await this._send('Target.attachToTarget', { targetId, flatten: true });

--- a/src/extension.js
+++ b/src/extension.js
@@ -241,6 +241,7 @@ function activate(context) {
     connectionManager = new ConnectionManager({
         log,
         getPort: getConfiguredPort,
+        windowName: vscode.workspace.name || '',
         getCustomTexts: () => vscode.workspace.getConfiguration('autoAcceptV2').get('customButtonTexts', [])
     });
 


### PR DESCRIPTION
### Background & Motivation

When multiple Antigravity windows are open, the CDP debugging port (default 9333) is process-wide — a single WebSocket connection sees all targets across all windows. This means toggling AutoAccept ON in window A causes its [ConnectionManager](cci:2://file:///C:/Users/Dongmay/AppData/Local/Temp/upstream-cm.js:9:0-416:1) to discover and inject MutationObservers into window B's, window C's, and even hidden internal pages (like "Launchpad").

The result: buttons in windows where AutoAccept is OFF get auto-clicked by the ON window's observer — a cross-window interference bug.

### Changes

| File | Change | +/- |
|------|--------|-----|
| [src/cdp/ConnectionManager.js](cci:7://file:///d:/ONE/CODE/AntiGravity-AutoAccept/src/cdp/ConnectionManager.js:0:0-0:0) | Accept `windowName` param; filter `page` targets by matching `title` to workspace name before attaching | +17 ~-1~ |
| [src/extension.js](cci:7://file:///d:/ONE/CODE/AntiGravity-AutoAccept/src/extension.js:0:0-0:0) | Pass `vscode.workspace.name` to [ConnectionManager](cci:2://file:///C:/Users/Dongmay/AppData/Local/Temp/upstream-cm.js:9:0-416:1) | +1 |

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Multiple windows, only one has AutoAccept ON | ON window injects observers into ALL windows' page targets | ON window only injects into its own page target |
| No workspace open (`vscode.workspace.name` is undefined) | N/A | Falls back to no filtering (backward compatible) |

### Verification

- [ ] Open 2+ Antigravity windows with different workspaces
- [ ] Toggle ON in one window only
- [ ] Check Output Channel — other windows' page targets should show `✗ Skipped [...] — window "..." ≠ "..."`
- [ ] Confirm no buttons are auto-clicked in the OFF window
