### PR TITLE
fix: include taskbar pinned shortcuts in CDP auto-fix scan

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -135,7 +135,7 @@ function applyPermanentWindowsPatch(targetPort) {
     const psContent = `
 $flag = "--remote-debugging-port=${targetPort}"
 $WshShell = New-Object -comObject WScript.Shell
-$paths = @("$env:USERPROFILE\\\\Desktop", "$env:PUBLIC\\\\Desktop", "$env:APPDATA\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs", "$env:ALLUSERSPROFILE\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs")
+$paths = @("$env:USERPROFILE\\\\Desktop", "$env:PUBLIC\\\\Desktop", "$env:APPDATA\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs", "$env:ALLUSERSPROFILE\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs", "$env:APPDATA\\\\Microsoft\\\\Internet Explorer\\\\Quick Launch\\\\User Pinned\\\\TaskBar")
 $patched = $false
 $manualFixNeeded = $false
 $patchedLnk = $null


### PR DESCRIPTION
### Background & Motivation

The Auto-Fix shortcut patcher scans Desktop and Start Menu for `.lnk` files to add `--remote-debugging-port`, but misses the taskbar — which is the most common launch method for many Windows users. Users who only have a taskbar-pinned Antigravity shortcut must manually edit it.

### Changes

| File | Change | +/- |
|------|--------|-----|
| [src/extension.js](cci:7://file:///d:/ONE/CODE/AntiGravity-AutoAccept/src/extension.js:0:0-0:0) | Add `%APPDATA%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar` to the patcher's scan paths | +1 ~-1~ |

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| User launches Antigravity from taskbar pin | Auto-Fix cannot find or patch the shortcut | Auto-Fix detects and patches the taskbar shortcut |

### Verification

- [ ] Pin Antigravity to taskbar (if not already)
- [ ] Remove `--remote-debugging-port=9333` from the taskbar shortcut's Arguments
- [ ] Trigger Auto-Fix (disable CDP port → restart → click "Auto-Fix Shortcut")
- [ ] Verify the taskbar shortcut now contains the flag
